### PR TITLE
WIP: Persistent child using multiprocessing and queues

### DIFF
--- a/sandbox/config.py
+++ b/sandbox/config.py
@@ -79,11 +79,14 @@ class SandboxConfig(object):
 
          - use_subprocess=True (bool): if True, execute() run the code in
            a subprocess
+         - persistent_child (bool): if True, the child process will be
+           persistent.
          - cpython_restricted=False (bool): if True, use CPython restricted
            mode instead of the _sandbox module
         """
         self.recusion_limit = 50
         self._use_subprocess = kw.get('use_subprocess', True)
+        self._persistent_child = kw.get('persistent_child', False)
         if self._use_subprocess:
             self._timeout = DEFAULT_TIMEOUT
             if resource is not None:
@@ -206,6 +209,10 @@ class SandboxConfig(object):
     @property
     def use_subprocess(self):
         return self._use_subprocess
+
+    @property
+    def persistent_child(self):
+        return self._persistent_child
 
     def _get_timeout(self):
         return self._timeout

--- a/sandbox/persistent_child.py
+++ b/sandbox/persistent_child.py
@@ -1,0 +1,87 @@
+import os
+import types
+import signal
+import marshal
+import resource
+import Queue
+import multiprocessing
+
+from sandbox import Sandbox, Timeout
+
+
+class PersistentChild(multiprocessing.Process):
+
+    def __init__(self, config):
+        self.config = config
+        self.taskq = multiprocessing.Queue()
+        self.resultq = multiprocessing.Queue()
+        multiprocessing.Process.__init__(self)
+
+    def _run_task(self, task):
+        self.taskq.put(task)
+        config = task.get("config", self.config)
+        try:
+            out = self.resultq.get(timeout=config.timeout)
+        except Queue.Empty:
+            self.terminate()
+            raise Timeout()
+        else:
+            if "error" in out:
+                raise out["error"]
+            for k in ("locals", "globals"):
+                if task.get(k, None) is not None:
+                    task[k].clear()
+                    task[k].update(out[k])
+            return out["result"]
+
+    def call(self, func, args, kw):
+        return self._run_task({
+            "config": self.config,
+            "func": marshal.dumps(func.func_code),
+            "name": func.__name__,
+            "args": args,
+            "kw": kw,
+        })
+
+    def execute(self, config, code, globals, locals):
+        return self._run_task({
+            "config": config,
+            "code": code,
+            "globals": globals,
+            "locals": locals,
+        })
+
+    def process_task(self, task):
+        try:
+            sandbox = Sandbox(task["config"])
+            if "code" in task:
+                result = sandbox._execute(
+                    task["code"], task["globals"], task["locals"])
+            else:
+                func = types.FunctionType(
+                    marshal.loads(task["func"]), globals(), task["name"])
+                result = sandbox._call(func, task["args"], task["kw"])
+            out = {"result": result}
+        except Exception, err:
+            out = {"error": err}
+        if task.get("globals", None) is not None:
+            del task["globals"]["__builtins__"]
+            out["globals"] = task["globals"]
+        if task.get("locals", None) is not None:
+            out["locals"] = task["locals"]
+        self.resultq.put(out)
+
+    def run(self):
+        # FIXME: multiprocessing.Queue use threading
+        #resource.setrlimit(resource.RLIMIT_NPROC, (0, 0))
+        resource.setrlimit(resource.RLIMIT_AS, (self.config.max_memory, -1))
+        # FIXME: stdout/stderr ?
+        while True:
+            try:
+                task = self.taskq.get(timeout=5)
+            except Queue.Empty:
+                if os.getppid() == 1:
+                    # Parent died, suicide myself
+                    os.kill(os.getpid(), signal.KILL)
+            else:
+                self.process_task(task)

--- a/sandbox/test/__init__.py
+++ b/sandbox/test/__init__.py
@@ -17,10 +17,14 @@ def createSandboxConfig(*features, **kw):
     if (createSandboxConfig.use_subprocess is not None) \
     and ('use_subprocess' not in kw):
         kw['use_subprocess'] = createSandboxConfig.use_subprocess
+    if (createSandboxConfig.persistent_child is not None) \
+    and ('persistent_child' not in kw):
+        kw['persistent_child'] = createSandboxConfig.persistent_child
     return SandboxConfig(*features, **kw)
 createSandboxConfig.debug = False
 createSandboxConfig.cpython_restricted = None
 createSandboxConfig.use_subprocess = None
+createSandboxConfig.persistent_child = None
 
 def createSandbox(*features):
     config = createSandboxConfig(*features)

--- a/tests.py
+++ b/tests.py
@@ -25,12 +25,15 @@ def parseOptions():
         exit(1)
     return options
 
-def run_tests(options, use_subprocess, cpython_restricted):
-    print("Run tests with cpython_restricted=%s and use_subprocess=%s"
-          % (cpython_restricted, use_subprocess))
+def run_tests(options, use_subprocess, cpython_restricted, persistent_child):
+    print((
+        "Run tests with cpython_restricted=%s, use_subprocess=%s "
+        "and persistent_child=%s") % (
+        cpython_restricted, use_subprocess, persistent_child))
     print("")
     createSandboxConfig.cpython_restricted = cpython_restricted
     createSandboxConfig.use_subprocess = use_subprocess
+    createSandboxConfig.persistent_child = persistent_child
 
     # Get all tests
     all_tests = getTests(globals(), options.keyword)
@@ -73,13 +76,15 @@ def main():
 
     nskipped, nerrors, ntests = 0, 0, 0
     for use_subprocess in (False, True):
-        for cpython_restricted in (False, True):
-            result = run_tests(options, use_subprocess, cpython_restricted)
-            nskipped += result[0]
-            nerrors += result[1]
-            ntests += result[2]
-            if options.raise_exception and nerrors:
-                break
+        for persistent_child in (False, True):
+            for cpython_restricted in (False, True):
+                result = run_tests(options, use_subprocess,
+                                   cpython_restricted, persistent_child)
+                nskipped += result[0]
+                nerrors += result[1]
+                ntests += result[2]
+                if options.raise_exception and nerrors:
+                    break
 
     # Exit
     from sys import exit


### PR DESCRIPTION
Hi haypo, thanks for pysandbox!

I plan to use it in production in a application which process lot of data and we want to provide user scripts for post-processing. But as these scripts are executed very often, we can't spawn a subprocess for each. So there is work in progress to use the same process to execute unsafe code.

Let me known what you thinks about the code, and if you're interested I'll be happy to improve it given what you say.

Encore merci ;)

COMMIT MESSAGE:

Prevent creation of a subprocess for each call on call() or execute() by
using a single process per Sandbox instance. This improve the
performance when using many call()/execute() on the same Sandbox
instance.

The process will be killed an re spawned if it takes more than
config.timeout to execute a single task.

The process is started on first call on call() or execute() and
terminated when the sandbox instance deleted or when the parent died.

USAGE:

> > > from sandbox import Sandbox, SandboxConfig
> > > sandbox = Sandbox(config=SandboxConfig(persistent_child=True))
> > > ctx = {"a": 1, "b": 2}
> > > sandbox.execute("c = a + b", None, {"a": 1, "b": 2})
> > > ctx
> > > {"a": 1, "b": 2, "c": 3}
> > > sandbox.call(lambda x: x, 1)
> > > 1

TODO:
- call() only work for simple functions without external dependencies.
  It's seems hard to fix. But in the use case of a constant function
  with pickables arguments, we may instantiate the child and give him a
  reference to the function.
- multiprocessing.Queue() use threading, thus we can't limit thread
  creation in the child process. Maybe we should use a lower level
  queue class
- stdout/stderr not tested
- Only tested with python 2.7 on Debian.
